### PR TITLE
Use ES Module script pattern

### DIFF
--- a/source/stencil-utilities/addon-assets/index.js
+++ b/source/stencil-utilities/addon-assets/index.js
@@ -25,6 +25,13 @@ const getOrCreateElement = (id, src) => {
   //   Check is string is JS
   if (src.match(/(.js)$/gi)) {
     element = document.createElement('script');
+
+    if (src.match(/(.esm.js)$/gi)) {
+      element.setAttribute('type', 'module')
+    } else {
+      element.setAttribute('nomodule', '')
+    }
+
     element.src = src;
   }
   //   Check is string is CSS

--- a/source/storybook/stencil.js
+++ b/source/storybook/stencil.js
@@ -40,6 +40,10 @@ const getStencilResources = () => ({
     process.env.NODE_ENV === 'development'
       ? `${protocol}://${host}:${port}/${buildDir}/${normalizedPkgName}.js`
       : `/${buildDir}/${normalizedPkgName}.js`,
+  'component-js-module':
+    process.env.NODE_ENV === 'development'
+      ? `${protocol}://${host}:${port}/${buildDir}/${normalizedPkgName}.esm.js`
+      : `/${buildDir}/${normalizedPkgName}.esm.js`,
 });
 /**
  * With assets custom decorator


### PR DESCRIPTION
When using this package with a newer version of stencil (1.0.7), it gives this error:

![Screenshot 2019-07-03 at 17 10 36](https://user-images.githubusercontent.com/11621275/60603523-36c50100-9db6-11e9-9dd2-043e61a3d339.png)

This PR adds the `.esm.js` file in a script tag in the `head` and add the `nomodule` attribute to the existing script tag. This way stencil is satisfied and doesn't throw the error anymore.